### PR TITLE
fixing DNS issues in openshift

### DIFF
--- a/3scale-gateway-openshift-template.yml
+++ b/3scale-gateway-openshift-template.yml
@@ -100,6 +100,8 @@ objects:
             value: ${THREESCALE_ADMIN_URL}
           - name: THREESCALE_PROVIDER_KEY
             value: ${THREESCALE_PROVIDER_KEY}
+          - name: RESOLVER
+            value: ${RESOLVER}
           image: ${THREESCALE_GATEWAY_NAME}
           imagePullPolicy: Always
           name: docker-gateway
@@ -158,3 +160,7 @@ parameters:
   value: threescalegw
   name: THREESCALE_GATEWAY_NAME
   required: true
+- description: DNS Resolver for openresty
+  value:
+  name: RESOLVER
+  required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,14 @@
 # 3scale (operations@3scale.net)
 set -u
 
-NAMESERVER=$(grep "nameserver" /etc/resolv.conf | awk '{print $2}' | tr '\n' ' ')
+export NAMESERVER
+
+if [ -v OPENSHIFT_BUILD_NAME ]; then
+	NAMESERVER=$(ip route | awk '/default/ {print $3}')
+	else
+	NAMESERVER=$(grep "nameserver" /etc/resolv.conf | awk '{print $2}' | tr '\n' ' ')
+fi
+
 export RESOLVER=${RESOLVER:-${NAMESERVER}}
 
 


### PR DESCRIPTION
- Detect if we are in openshift, use default route
- If we are not in openshift, use /etc/resolv.conf
- Let user set the resolver