### PR TITLE
entrypoint was failing on nslookup failure, this fixes the issue by shelling out the var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,6 @@ test-docker: build
 	$(DOCKER_COMPOSE) down --volumes --remove-orphans
 	$(DOCKER_COMPOSE) run --rm --user 100001 gateway openresty -p . -t
 	$(DOCKER_COMPOSE) run --rm --user 100001 gateway openresty -p .
+	$(DOCKER_COMPOSE) run --rm --user 100001 gateway /opt/app/entrypoint.sh
+	$(DOCKER_COMPOSE) run --rm test /opt/app/entrypoint.sh | grep 'error: no working DNS server'
 	$(DOCKER_COMPOSE) run --rm test curl -v http://gateway:8090/status/live

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   gateway:
     image: docker-gateway-test
-    user: '1000001'
     ports:
       - "8080:8080"
       - "8090:8090"
@@ -12,3 +11,4 @@ services:
     depends_on:
       - gateway
     entrypoint: ""
+    dns: 127.0.0.1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,12 +18,14 @@ pick_dns_server() {
     echo "127.0.0.1"
   else
     for server in $DNS; do
-      ret=$(nslookup -timeout=1 -retry=3 redhat.com "$server" &> /dev/null) 
-      if [ $? -eq 0 ]; then
+      if (nslookup -timeout=1 -retry=3 redhat.com "$server" &> /dev/null); then
         echo "$server"
-        break
+	 exit 0
       fi
     done
+
+    (>&2 echo "error: no working DNS server found")
+    exit 1
   fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ pick_dns_server() {
     echo "127.0.0.1"
   else
     for server in $DNS; do
-      nslookup redhat.com "$server" &> /dev/null
+      ret=$(nslookup -timeout=1 -retry=3 redhat.com "$server" &> /dev/null) 
       if [ $? -eq 0 ]; then
         echo "$server"
         break


### PR DESCRIPTION
nslookup call was crashing the entrypoint,
so shell out to prevent the crash and test it works with invalid dns