### PR TITLE
load configuration at boot time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,6 @@ test-docker: build
 	$(DOCKER_COMPOSE) run --rm --user 100001 gateway /opt/app/entrypoint.sh
 	$(DOCKER_COMPOSE) run --rm test /opt/app/entrypoint.sh | grep 'error: no working DNS server'
 	$(DOCKER_COMPOSE) run --rm test curl --fail http://gateway:8090/status/live
+	$(DOCKER_COMPOSE) run --rm test curl --fail -X PUT http://gateway:8090/config --data '{"services":[{"id":42}]}'
+	$(DOCKER_COMPOSE) run --rm test curl --fail http://gateway:8090/status/ready
 	$(DOCKER_COMPOSE) run --rm test curl --fail -X POST http://gateway:8090/boot

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -34,6 +34,12 @@ http {
 
   init_by_lua_block {
     require('luarocks.loader')
+
+    local config = require('configuration').init()
+
+    if config then
+      require('provider').init(config)
+    end
   }
 
   include ../http.d/*.conf;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -30,7 +30,7 @@ http {
   lua_package_path ";;${prefix}?.lua;${prefix}src/?.lua";
 
   # Enabling the Lua code cache is strongly encouraged for production use. Here it is enabled by default for testing and development purposes
-  lua_code_cache off;
+  lua_code_cache on;
 
   init_by_lua_block {
     require('luarocks.loader')

--- a/libexec/boot
+++ b/libexec/boot
@@ -1,0 +1,10 @@
+#!/usr/bin/env resty
+
+require 'luarocks.loader'
+package.path = package.path .. ";./src/?.lua"
+
+local configuration = require 'configuration'
+
+local config = configuration.boot()
+
+ngx.say(config)

--- a/src/configuration.lua
+++ b/src/configuration.lua
@@ -207,6 +207,26 @@ function _M.load()
   return _M.config
 end
 
+function _M.init()
+  local tmpname = os.tmpname()
+  local exit = os.execute(ngx.config.prefix() .. '/libexec/boot > ' .. tmpname)
+
+  if exit == 0 then
+    local handle, err = io.open(tmpname)
+
+    if handle then
+      local config = handle:read("*a")
+      handle:close()
+
+      return config
+    else
+      ngx.log(ngx.ERR, 'boot failed read: ' .. tmpname .. ' ' .. tostring(err))
+    end
+  else
+    ngx.log(ngx.NOTICE, 'boot could not get configuration, code: ' .. tostring(exit))
+  end
+end
+
 function _M.download(endpoint)
   if not endpoint then
     return nil, 'missing endpoint'


### PR DESCRIPTION
that should make readiness probe to mark instance as live
without requiring to make any request to it