### PR TITLE
fix crash when using ngx.re in init_by_lua

### DIFF
--- a/src/configuration.lua
+++ b/src/configuration.lua
@@ -86,7 +86,6 @@ function _M.parse_service(service)
       backend_version = tostring(service.backend_version),
       hosts = proxy.hosts or { 'localhost' }, -- TODO: verify localhost is good default
       api_backend = proxy.api_backend,
-      api_backend_host = (_M.url(proxy.api_backend) or {})[4],
       error_auth_failed = proxy.error_auth_failed,
       error_auth_missing = proxy.error_auth_missing,
       auth_failed_headers = proxy.error_headers_auth_failed,

--- a/src/provider.lua
+++ b/src/provider.lua
@@ -216,6 +216,7 @@ end
 function _M.access(host)
   local host = host or ngx.var.host
   local service = _M.find_service(host) or ngx.exit(404)
+  local host = (configuration.url(service.api_backend) or {})[4]
   local backend_version = service.backend_version
   local params = {}
   local usage = {}
@@ -281,7 +282,7 @@ function _M.access(host)
 
   ngx.var.service_id = tostring(service.id)
   ngx.var.proxy_pass = service.api_backend or error('missing api backend')
-  ngx.req.set_header('Host', service.hostname_rewrite or service.api_backend_host or ngx.var.host)
+  ngx.req.set_header('Host', service.hostname_rewrite or host or ngx.var.host)
 
   _M.authorize(backend_version, params, service)
 end


### PR DESCRIPTION
```
2016/09/09 15:57:50 [error] 1#1: init_by_lua error: /opt/app/src/configuration.lua:282: no request object found
stack traceback:
	[C]: in function 'match'
	/opt/app/src/configuration.lua:282: in function 'url'
	/opt/app/src/configuration.lua:89: in function 'func'
	/opt/app/src/configuration.lua:14: in function 'map'
	/opt/app/src/configuration.lua:196: in function 'parse'
	/opt/app/src/provider.lua:20: in function 'configure'
	/opt/app/src/provider.lua:29: in function 'init'
	init_by_lua:7: in main chunk
```
introduced in #57
/cc @jmprusi 