### PR TITLE
disable ssl validation

### DIFF
--- a/http.d/lua_ssl.conf
+++ b/http.d/lua_ssl.conf
@@ -1,2 +1,8 @@
-lua_ssl_verify_depth 5;
-lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;
+## Customize this file to set up proper ssl validation.
+## Openresty/Nginx can't use system certificates:
+## https://groups.google.com/forum/#!topic/openresty-en/SuqORBK9ys0
+## So you have to point it to some ca-bundle which makes
+## it really hard to have working cross platform configuration.
+#
+# lua_ssl_verify_depth 5;
+# lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;


### PR DESCRIPTION
there is no way to write working cross platform configuration
so every platform will be responsible for bootstraping it